### PR TITLE
Use new shortcode syntax

### DIFF
--- a/content/posts/2014-12-21-dynamic-pages-with-gohugo.md
+++ b/content/posts/2014-12-21-dynamic-pages-with-gohugo.md
@@ -44,7 +44,7 @@ As an example I'm using the JSON from my [GitHub Stars](https://api.github.com/u
 In your markdown template you can e.g. add a short code like:
 
 ```
-{ {% jsonGH 0 %}}
+{{</* jsonGH 0 */>}}
 ```
 
 The 0 indicates which index to use in the json list within front matters.
@@ -69,15 +69,15 @@ The jsonGH short code template is:
 
 Parsing index 0:
 
-{{% jsonGH 0 %}}
+{{< jsonGH 0 >}}
 
 Parsing index 1:
 
-{{% jsonGH 1 %}}
+{{< jsonGH 1 >}}
 
 Parsing YouTube feed url:
 
-{{% jsonYt 2 %}}
+{{< jsonYt 2 >}}
 
 One strange problem occurs when parsing the Youtube API 2.0 (deprecated):
 


### PR DESCRIPTION
Since this page depends on brand new Hugo code, you might as well use the new syntax. {{< means no Markdown processing.

Oh, and if you want pull requests to this blog, I would put /public in .gitignore.

One more comment:

I really like this feature, but I see no big point in the index/url in frontmatter. Adding the urls/paths to the jsons directly in the function (GetJson(http://...) would  make it cleaner.
